### PR TITLE
change path to env

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 import fs from 'fs'
 import program from 'commander'


### PR DESCRIPTION
On Mac OS X Mojave, `env` is not available at the path of `/bin/env`.